### PR TITLE
Add UnresolvedBranch to BranchType

### DIFF
--- a/src/binja_test_mocks/binja_api.py
+++ b/src/binja_test_mocks/binja_api.py
@@ -52,6 +52,7 @@ if not _has_binja():
         FalseBranch = 2
         CallDestination = 3
         FunctionReturn = 4
+        UnresolvedBranch = 127
 
     class InstructionTextTokenType(enum.Enum):
         InstructionToken = 0

--- a/tests/test_basic_import.py
+++ b/tests/test_basic_import.py
@@ -29,6 +29,16 @@ def test_binja_api_import() -> None:
     assert RegisterName is not None
 
 
+def test_branchtype_has_unresolved_branch() -> None:
+    """Test that BranchType includes UnresolvedBranch for no-fallthrough CFG edges."""
+    import importlib
+
+    importlib.import_module("binja_test_mocks.binja_api")
+    branch_type = importlib.import_module("binaryninja.enums").BranchType
+
+    assert branch_type.UnresolvedBranch is not None
+
+
 def test_mock_llil() -> None:
     """Test mock LLIL functionality."""
     from binja_test_mocks import binja_api  # noqa: F401


### PR DESCRIPTION
Add `BranchType.UnresolvedBranch` to the mock `binaryninja.enums.BranchType` enum so plugins can model non-fallthrough edges with unknown destinations (e.g., reset vectors) without abusing `FunctionReturn`.

Test plan:
- `uv run ruff check .`
- `uv run pytest -q`