### PR TITLE
Release v0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "binja-test-mocks"
-version = "0.1.4"
+version = "0.1.5"
 description = "Mock Binary Ninja API for testing Binary Ninja plugins without requiring a license"
 readme = "README.md"
 license = {text = "MIT"}
@@ -122,4 +122,3 @@ ignore = ["E501"]  # Line length handled by formatter
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]  # Allow assert in tests
-

--- a/src/binja_test_mocks/__init__.py
+++ b/src/binja_test_mocks/__init__.py
@@ -1,6 +1,6 @@
 """binja-test-mocks - Mock Binary Ninja API for testing plugins without a license."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.5"
 
 # Re-export commonly used items for convenience
 from . import binja_api


### PR DESCRIPTION
Bump package version to `0.1.5` for the next PyPI release.

Test plan:
- `uv run ruff check .`
- `uv run pytest -q`
