### PR TITLE
Add missing BN APIs for architecture plugins

### DIFF
--- a/src/binja_test_mocks/stubs/binaryninja/enums.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/enums.pyi
@@ -9,3 +9,5 @@ Endianness: Any
 FlagRole: Any
 ImplicitRegisterExtend: Any
 ActionType: Any
+LowLevelILOperation: Any
+LowLevelILFlagCondition: Any

--- a/src/binja_test_mocks/stubs/binaryninja/interaction.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/interaction.pyi
@@ -3,3 +3,11 @@ from typing import Any
 class UIContext:
     @staticmethod
     def activeContext() -> Any: ...  # noqa: N802
+
+class AddressField:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+class ChoiceField:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+def get_form_input(*args: Any, **kwargs: Any) -> bool: ...

--- a/src/binja_test_mocks/stubs/binaryninja/lowlevelil.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/lowlevelil.pyi
@@ -24,7 +24,11 @@ class LowLevelILFunction:
     def expr(self, *args: Any, size: int | None, flags: Any | None = None) -> ExpressionIndex: ...
     def reg(self, size: int, reg: RegisterName | ILRegister | RegisterIndex) -> ExpressionIndex: ...
     def set_reg(
-        self, size: int, reg: RegisterName | ILRegister | RegisterIndex, value: Any
+        self,
+        size: int,
+        reg: RegisterName | ILRegister | RegisterIndex,
+        value: Any,
+        flags: Any | None = None,
     ) -> ExpressionIndex: ...
     def intrinsic(
         self,

--- a/src/binja_test_mocks/stubs/binaryninja/plugin.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/plugin.pyi
@@ -1,0 +1,7 @@
+from typing import Any
+
+class PluginCommand:
+    @staticmethod
+    def register_for_address(*args: Any, **kwargs: Any) -> None: ...
+    @staticmethod
+    def register(*args: Any, **kwargs: Any) -> None: ...

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "binja-test-mocks"
-version = "0.1.3"
+version = "0.1.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Provide `binaryninja.plugin.PluginCommand` and expand `binaryninja.interaction` (`AddressField`/`ChoiceField`/`get_form_input`)
- Make mock LLIL usable as `binaryninja.lowlevelil.LowLevelILFunction` (accept `arch` arg, `append`/`__iter__`/`__getitem__`, stable `get_label_for_address`, `flag_condition`)
- Update stubs accordingly

Motivation: run `mblsha/binaryninja-m68k` unit tests on CI without a real Binary Ninja install.