### PR TITLE
MockLLIL: add LowLevelILInstruction-compatible properties

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -12,7 +12,7 @@
     "src/binja_test_mocks/stubs"
   ],
   "extraPaths": [
-    "/Users/mblsha/Library/Application Support/Binary Ninja/plugins/binja-test-mocks/src/binja_test_mocks/stubs"
+    "src/binja_test_mocks/stubs"
   ],
   "typeCheckingMode": "basic",
   "pythonVersion": "3.10",
@@ -29,5 +29,5 @@
   "reportInvalidTypeForm": false,
   "reportUnusedImport": false,
   "reportUnusedFunction": false,
-  "stubPath": "/Users/mblsha/Library/Application Support/Binary Ninja/plugins/binja-test-mocks/src/binja_test_mocks/stubs"
+  "stubPath": "src/binja_test_mocks/stubs"
 }

--- a/src/binja_test_mocks/mock_llil.py
+++ b/src/binja_test_mocks/mock_llil.py
@@ -104,6 +104,32 @@ class MockLLIL:
     def bare_op(self) -> str:
         return self.op.split("{")[0].split(".")[0]
 
+    @property
+    def operation(self) -> Any:
+        """Binary Ninja-compatible operation enum for this instruction."""
+        from binaryninja.enums import LowLevelILOperation
+
+        return getattr(LowLevelILOperation, f"LLIL_{self.bare_op()}")
+
+    @property
+    def operands(self) -> list[Any]:
+        """Binary Ninja-compatible operand list for this instruction."""
+        return self.ops
+
+    @property
+    def size(self) -> int | None:
+        """Binary Ninja-compatible size (in bytes) for this instruction, if any."""
+        return self.width()
+
+    @property
+    def constant(self) -> int:
+        """Binary Ninja-compatible constant value for CONST/CONST_PTR instructions."""
+        from binaryninja.enums import LowLevelILOperation
+
+        if self.operation in (LowLevelILOperation.LLIL_CONST, LowLevelILOperation.LLIL_CONST_PTR):
+            return int(self.ops[0])
+        raise AttributeError("Instruction has no constant")
+
 
 ExprType = MockLLIL | ExpressionIndex
 

--- a/tests/test_basic_import.py
+++ b/tests/test_basic_import.py
@@ -51,6 +51,38 @@ def test_mock_llil() -> None:
     assert il.ils[0].op == "NOP"
 
 
+def test_mock_llil_instruction_surface() -> None:
+    """Test Binary Ninja-like LowLevelILInstruction helpers on MockLLIL."""
+    from typing import Any, cast
+
+    import pytest
+    from binaryninja.enums import LowLevelILOperation
+
+    from binja_test_mocks import binja_api  # noqa: F401
+    from binja_test_mocks.mock_llil import MockLowLevelILFunction
+
+    il = MockLowLevelILFunction()
+
+    const = cast(Any, il.const(4, -1))
+    assert const.operation == LowLevelILOperation.LLIL_CONST
+    assert const.operands == [-1]
+    assert const.size == 4
+    assert const.constant == -1
+
+    const_ptr = cast(Any, il.const_pointer(4, 0x1234))
+    assert const_ptr.operation == LowLevelILOperation.LLIL_CONST_PTR
+    assert const_ptr.operands == [0x1234]
+    assert const_ptr.size == 4
+    assert const_ptr.constant == 0x1234
+
+    reg = cast(Any, il.reg(4, "d0"))
+    assert reg.operation == LowLevelILOperation.LLIL_REG
+    assert reg.size == 4
+    assert getattr(reg.operands[0], "name", None) == "d0"
+    with pytest.raises(AttributeError):
+        _ = reg.constant
+
+
 def test_tokens() -> None:
     """Test token utilities."""
     from binja_test_mocks import binja_api  # noqa: F401

--- a/tests/test_basic_import.py
+++ b/tests/test_basic_import.py
@@ -58,10 +58,15 @@ def test_mock_llil_instruction_surface() -> None:
     import pytest
     from binaryninja.enums import LowLevelILOperation
 
-    from binja_test_mocks import binja_api  # noqa: F401
+    from binja_test_mocks import (
+        binja_api,  # noqa: F401
+        mock_llil,
+    )
     from binja_test_mocks.mock_llil import MockLowLevelILFunction
 
     il = MockLowLevelILFunction()
+
+    mock_llil.set_size_lookup({1: ".b", 2: ".w", 4: ".d"}, {"b": 1, "w": 2, "d": 4})
 
     const = cast(Any, il.const(4, -1))
     assert const.operation == LowLevelILOperation.LLIL_CONST


### PR DESCRIPTION
Adds `operation`, `operands`, `size`, and `constant` helpers to `MockLLIL` so architecture plugins that introspect temporary IL (e.g. `binaryninja-m68k`) can run under the mocks.

Also makes `pyrightconfig.json` use a repo-relative stub path.
