### PR TITLE
Mock InstructionTextToken: accept value and size

### DIFF
--- a/src/binja_test_mocks/binja_api.py
+++ b/src/binja_test_mocks/binja_api.py
@@ -109,12 +109,23 @@ if not _has_binja():
 
     class InstructionTextToken:
         def __init__(
-            self, type_arg: InstructionTextTokenType, text: str, value: Any = None
+            self,
+            type_arg: InstructionTextTokenType,
+            text: str,
+            value: Any = None,
+            size: int | None = None,
+            *_args: Any,
+            **_kwargs: Any,
         ) -> None:
-            """Initialize InstructionTextToken, ignoring optional value parameter."""
+            """Initialize InstructionTextToken.
+
+            Binary Ninja's real API accepts optional `value` and `size` args.
+            Some plugins also pass additional positional arguments; ignore them.
+            """
             self.type = type_arg
             self.text = text
-            # Note: value parameter is ignored for compatibility with plugins that pass it
+            self.value = value
+            self.size = size
 
     bn.InstructionTextToken = InstructionTextToken  # type: ignore [attr-defined]
 

--- a/tests/test_basic_import.py
+++ b/tests/test_basic_import.py
@@ -105,6 +105,19 @@ def test_tokens() -> None:
     assert hasattr(text_token.__class__, "token_type")
 
 
+def test_instruction_text_token_accepts_value_and_size() -> None:
+    """Some plugins pass `value` + `size` to InstructionTextToken."""
+    from binaryninja import InstructionTextToken
+    from binaryninja.enums import InstructionTextTokenType
+
+    from binja_test_mocks import binja_api  # noqa: F401
+
+    tok = InstructionTextToken(InstructionTextTokenType.IntegerToken, "$01", 1, 1)
+    assert tok.text == "$01"
+    assert tok.value == 1
+    assert tok.size == 1
+
+
 def test_stubs_available() -> None:
     """Test that type stubs are accessible."""
     from pathlib import Path


### PR DESCRIPTION
Binary Ninja arch plugins (e.g. `binaryninja-m68k`) often call `InstructionTextToken(token_type, text, value, size)`.

This makes the mock constructor accept and store `value` + `size` (and ignore any extra args) so disassembly formatting can run under the mocks.
