### PR TITLE
Avoid clobbering real Binary Ninja

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "binja-test-mocks"
-version = "0.1.8"
+version = "0.1.9"
 description = "Mock Binary Ninja API for testing Binary Ninja plugins without requiring a license"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/binja_test_mocks/__init__.py
+++ b/src/binja_test_mocks/__init__.py
@@ -1,6 +1,6 @@
 """binja-test-mocks - Mock Binary Ninja API for testing plugins without a license."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 # Re-export commonly used items for convenience
 from . import binja_api

--- a/tests/test_binary_ninja_guard.py
+++ b/tests/test_binary_ninja_guard.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_force_mock_is_ignored_inside_binary_ninja_process() -> None:
+    """FORCE_BINJA_MOCK must not clobber a real Binary Ninja runtime."""
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+
+    env = os.environ.copy()
+    env["FORCE_BINJA_MOCK"] = "1"
+    env.pop("ALLOW_BINJA_MOCK_IN_BINARY_NINJA", None)
+
+    # Ensure the subprocess imports this checkout, not an installed wheel.
+    env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+
+    code = """
+import sys
+sys.executable = "binaryninja"
+
+import binja_test_mocks.binja_api  # noqa: F401
+
+import sys as _sys
+print("binaryninja" in _sys.modules)
+""".strip()
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(repo_root),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "False"
+

--- a/tests/test_binary_ninja_guard.py
+++ b/tests/test_binary_ninja_guard.py
@@ -37,4 +37,3 @@ print("binaryninja" in _sys.modules)
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "False"
-

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "binja-test-mocks"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
When running inside the actual Binary Ninja app, importing  should never install the stub  module (even if ).\n\n- Detects Binary Ninja runtime via  and  module presence\n- Ignores  inside BN unless \n- Adds a regression test ensuring  is not injected