### PR TITLE
Mock LLIL: emit IF/GOTO/LABEL nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "binja-test-mocks"
-version = "0.1.9"
+version = "0.1.10"
 description = "Mock Binary Ninja API for testing Binary Ninja plugins without requiring a license"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/binja_test_mocks/__init__.py
+++ b/src/binja_test_mocks/__init__.py
@@ -1,6 +1,6 @@
 """binja-test-mocks - Mock Binary Ninja API for testing plugins without a license."""
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 # Re-export commonly used items for convenience
 from . import binja_api

--- a/tests/test_mock_llil_control_flow.py
+++ b/tests/test_mock_llil_control_flow.py
@@ -1,0 +1,50 @@
+"""Regression tests for mock LLIL control-flow helpers (IF/GOTO/LABEL)."""
+
+import os
+
+os.environ["FORCE_BINJA_MOCK"] = "1"
+
+
+def test_mock_llil_control_flow_nodes() -> None:
+    from binaryninja.lowlevelil import LowLevelILLabel
+
+    from binja_test_mocks import binja_api  # noqa: F401
+    from binja_test_mocks.mock_llil import (
+        MockGoto,
+        MockIfExpr,
+        MockLabel,
+        MockLowLevelILFunction,
+    )
+
+    il = MockLowLevelILFunction()
+
+    label_true = LowLevelILLabel()
+    label_false = LowLevelILLabel()
+
+    cond = il.const(1, 1)
+    if_expr = il.if_expr(cond, label_true, label_false)
+
+    assert isinstance(if_expr, MockIfExpr)
+    assert if_expr.op == "IF"
+    assert if_expr.ops == [cond, label_true, label_false]
+    assert if_expr.cond is cond
+    assert if_expr.t is label_true
+    assert if_expr.f is label_false
+
+    il.append(if_expr)
+    il.mark_label(label_true)
+    goto = il.goto(label_false)
+    il.append(goto)
+    il.mark_label(label_false)
+
+    assert isinstance(il.ils[1], MockLabel)
+    assert il.ils[1].label is label_true
+
+    assert isinstance(il.ils[2], MockGoto)
+    assert il.ils[2].op == "GOTO"
+    assert il.ils[2].ops == [label_false]
+    assert il.ils[2].label is label_false
+
+    assert isinstance(il.ils[3], MockLabel)
+    assert il.ils[3].label is label_false
+

--- a/tests/test_mock_llil_control_flow.py
+++ b/tests/test_mock_llil_control_flow.py
@@ -47,4 +47,3 @@ def test_mock_llil_control_flow_nodes() -> None:
 
     assert isinstance(il.ils[3], MockLabel)
     assert il.ils[3].label is label_false
-

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "binja-test-mocks"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fixes control-flow lifting for projects like binja-esr by:
- Returning MockIfExpr/MockGoto from if_expr/goto
- Appending MockLabel nodes from mark_label

Also adds a regression test for these surfaces.
