### PR TITLE
Docs: add plugin integration guide

### DIFF
--- a/examples/basic_plugin/__init__.py
+++ b/examples/basic_plugin/__init__.py
@@ -1,24 +1,32 @@
 """Example Binary Ninja plugin using binja-test-mocks for testing."""
 
+from __future__ import annotations
+
+import importlib.util
 import os
 import sys
 from pathlib import Path
 
 # Add plugin directory to path
-plugin_dir = str(Path(__file__).resolve().parent)
-if plugin_dir not in sys.path:
-    sys.path.insert(0, plugin_dir)
+_plugin_dir = Path(__file__).resolve().parent
+if str(_plugin_dir) not in sys.path:
+    sys.path.insert(0, str(_plugin_dir))
 
-# For testing, load mock API
-if os.environ.get("FORCE_BINJA_MOCK") == "1":
-    from binja_test_mocks import binja_api  # noqa: F401
 
-# Check if we're running in Binary Ninja
-try:
-    from .example_arch import ExampleArchitecture
+def _running_inside_binary_ninja() -> bool:
+    try:
+        return importlib.util.find_spec("binaryninjaui") is not None
+    except (ValueError, ImportError):
+        return False
 
-    # Register the architecture
-    ExampleArchitecture.register()
-except ImportError:
-    # Not running in Binary Ninja, likely in test mode
-    pass
+
+_force_mock = os.environ.get("FORCE_BINJA_MOCK", "").lower() in ("1", "true", "yes")
+_skip_registration = _force_mock and not _running_inside_binary_ninja()
+
+if not _skip_registration:
+    try:
+        from .example_arch import ExampleArchitecture
+
+        ExampleArchitecture.register()
+    except ImportError:
+        pass


### PR DESCRIPTION
- Add a recommended `tests/conftest.py` pattern (FORCE_BINJA_MOCK + early `binja_test_mocks.binja_api` import).
- Document how mocks stay scoped to tests/CI and won’t clobber a real Binary Ninja process by default.
- Add practical guidance for byte-driven disassembly + LLIL test cases (including LABEL pseudo-nodes).
- Update the migration guide and the basic example plugin to avoid importing mocks from runtime plugin code.

Reference integration: https://github.com/mblsha/binaryninja-m68k/pull/1
