### PR TITLE
chore: release v0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "binja-test-mocks"
-version = "0.1.10"
+version = "0.1.11"
 description = "Mock Binary Ninja API for testing Binary Ninja plugins without requiring a license"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "binja-test-mocks"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- bump version to 0.1.11
- update uv.lock

## Testing
- not run (version bump)