### PR TITLE
[codex] Add HLIL mocks

### DIFF
--- a/src/binja_test_mocks/binja_api.py
+++ b/src/binja_test_mocks/binja_api.py
@@ -132,6 +132,18 @@ if not _has_binja():
     class ImplicitRegisterExtend(enum.Enum):
         SignExtendToFullWidth = 0
 
+    from .mock_hlil import HLIL_OPERATION_NAMES
+
+    class _NamedIntEnum(enum.IntEnum):
+        def __str__(self) -> str:
+            return f"{type(self).__name__}.{self.name}"
+
+    HighLevelILOperation = enum.IntEnum(  # type: ignore[misc]
+        "HighLevelILOperation",
+        {name: index for index, name in enumerate(HLIL_OPERATION_NAMES)},
+        type=_NamedIntEnum,
+    )
+
     enums_mod.BranchType = BranchType  # type: ignore [attr-defined]
     enums_mod.InstructionTextTokenType = InstructionTextTokenType  # type: ignore [attr-defined]
     enums_mod.SegmentFlag = SegmentFlag  # type: ignore [attr-defined]
@@ -140,10 +152,12 @@ if not _has_binja():
     enums_mod.Endianness = Endianness  # type: ignore [attr-defined]
     enums_mod.FlagRole = FlagRole  # type: ignore [attr-defined]
     enums_mod.ImplicitRegisterExtend = ImplicitRegisterExtend  # type: ignore [attr-defined]
+    enums_mod.HighLevelILOperation = HighLevelILOperation  # type: ignore [attr-defined]
     # Note: LowLevelILOperation and LowLevelILFlagCondition will be added after llil_mod is defined
 
     bn.enums = enums_mod  # type: ignore [attr-defined]
     bn.SymbolType = SymbolType  # type: ignore [attr-defined]
+    bn.HighLevelILOperation = HighLevelILOperation  # type: ignore [attr-defined]
     sys.modules["binaryninja.enums"] = enums_mod
 
     class InstructionTextToken:
@@ -301,10 +315,25 @@ if not _has_binja():
             # Create a mock architecture
             from .mock_llil import MockArch
 
-            self.arch = MockArch()
+            self.arch = kwargs.get("arch", MockArch())
+            self.start = int(kwargs.get("start", 0))
+            self.name = str(kwargs.get("name", "sub_0"))
+            self.type = kwargs.get("type", "void()")
+            self.return_type = kwargs.get("return_type", "void")
+            self.calling_convention = kwargs.get(
+                "calling_convention",
+                types.SimpleNamespace(name=kwargs.get("calling_convention_name", "cdecl")),
+            )
+            self.parameter_vars = list(kwargs.get("parameter_vars", []))
+            self.hlil_if_available = kwargs.get(
+                "hlil_if_available",
+                kwargs.get("high_level_il"),
+            )
+            self.high_level_il = kwargs.get("high_level_il", self.hlil_if_available)
 
     function_mod.Function = Function  # type: ignore [attr-defined]
     bn.function = function_mod  # type: ignore [attr-defined]
+    bn.Function = Function  # type: ignore [attr-defined]
     sys.modules["binaryninja.function"] = function_mod
 
     arch_mod = types.ModuleType("binaryninja.architecture")
@@ -738,6 +767,33 @@ if not _has_binja():
 
     llil_mod.LowLevelILFunction = MockLowLevelILFunction  # type: ignore [attr-defined]
     llil_mod.LowLevelILInstruction = MockLLIL  # type: ignore [attr-defined]
+
+    highlevelil_mod = types.ModuleType("binaryninja.highlevelil")
+    from .mock_hlil import (
+        MockHighLevelILFunction,
+        MockHighLevelILInstruction,
+        MockHLILStorage,
+        MockHLILVar,
+        mhlil,
+    )
+
+    highlevelil_mod.HighLevelILOperation = HighLevelILOperation  # type: ignore [attr-defined]
+    highlevelil_mod.HighLevelILFunction = MockHighLevelILFunction  # type: ignore [attr-defined]
+    highlevelil_mod.HighLevelILInstruction = MockHighLevelILInstruction  # type: ignore [attr-defined]
+    highlevelil_mod.MockHighLevelILFunction = MockHighLevelILFunction  # type: ignore [attr-defined]
+    highlevelil_mod.MockHighLevelILInstruction = MockHighLevelILInstruction  # type: ignore [attr-defined]
+    highlevelil_mod.MockHLILStorage = MockHLILStorage  # type: ignore [attr-defined]
+    highlevelil_mod.MockHLILVar = MockHLILVar  # type: ignore [attr-defined]
+    highlevelil_mod.mhlil = mhlil  # type: ignore [attr-defined]
+
+    bn.highlevelil = highlevelil_mod  # type: ignore [attr-defined]
+    bn.HighLevelILFunction = MockHighLevelILFunction  # type: ignore [attr-defined]
+    bn.HighLevelILInstruction = MockHighLevelILInstruction  # type: ignore [attr-defined]
+    bn.MockHighLevelILFunction = MockHighLevelILFunction  # type: ignore [attr-defined]
+    bn.MockHighLevelILInstruction = MockHighLevelILInstruction  # type: ignore [attr-defined]
+    bn.MockHLILStorage = MockHLILStorage  # type: ignore [attr-defined]
+    bn.MockHLILVar = MockHLILVar  # type: ignore [attr-defined]
+    sys.modules["binaryninja.highlevelil"] = highlevelil_mod
 
     @dataclass
     class InstructionInfo:

--- a/src/binja_test_mocks/mock_hlil.py
+++ b/src/binja_test_mocks/mock_hlil.py
@@ -1,0 +1,635 @@
+"""Make Binary Ninja HLIL unit-testable."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+HLIL_OPERATION_NAMES = (
+    "HLIL_NOP",
+    "HLIL_BLOCK",
+    "HLIL_IF",
+    "HLIL_WHILE",
+    "HLIL_DO_WHILE",
+    "HLIL_FOR",
+    "HLIL_SWITCH",
+    "HLIL_CASE",
+    "HLIL_BREAK",
+    "HLIL_CONTINUE",
+    "HLIL_JUMP",
+    "HLIL_RET",
+    "HLIL_NORET",
+    "HLIL_GOTO",
+    "HLIL_LABEL",
+    "HLIL_VAR_DECLARE",
+    "HLIL_VAR_INIT",
+    "HLIL_ASSIGN",
+    "HLIL_ASSIGN_UNPACK",
+    "HLIL_ASSIGN_MEM_SSA",
+    "HLIL_ASSIGN_UNPACK_MEM_SSA",
+    "HLIL_VAR",
+    "HLIL_STRUCT_FIELD",
+    "HLIL_DEREF_FIELD",
+    "HLIL_ARRAY_INDEX",
+    "HLIL_SPLIT",
+    "HLIL_DEREF",
+    "HLIL_ADDRESS_OF",
+    "HLIL_CONST",
+    "HLIL_CONST_PTR",
+    "HLIL_CONST_DATA",
+    "HLIL_IMPORT",
+    "HLIL_FLOAT_CONST",
+    "HLIL_EXTERN_PTR",
+    "HLIL_ADD",
+    "HLIL_ADC",
+    "HLIL_SUB",
+    "HLIL_SBB",
+    "HLIL_AND",
+    "HLIL_OR",
+    "HLIL_XOR",
+    "HLIL_LSL",
+    "HLIL_LSR",
+    "HLIL_ASR",
+    "HLIL_ROL",
+    "HLIL_RLC",
+    "HLIL_ROR",
+    "HLIL_RRC",
+    "HLIL_MUL",
+    "HLIL_MULU_DP",
+    "HLIL_MULS_DP",
+    "HLIL_DIVU",
+    "HLIL_DIVS",
+    "HLIL_DIVU_DP",
+    "HLIL_DIVS_DP",
+    "HLIL_MODU",
+    "HLIL_MODS",
+    "HLIL_MODU_DP",
+    "HLIL_MODS_DP",
+    "HLIL_NEG",
+    "HLIL_NOT",
+    "HLIL_SX",
+    "HLIL_ZX",
+    "HLIL_LOW_PART",
+    "HLIL_BOOL_TO_INT",
+    "HLIL_CMP_E",
+    "HLIL_CMP_NE",
+    "HLIL_CMP_SLT",
+    "HLIL_CMP_ULT",
+    "HLIL_CMP_SLE",
+    "HLIL_CMP_ULE",
+    "HLIL_CMP_SGE",
+    "HLIL_CMP_UGE",
+    "HLIL_CMP_SGT",
+    "HLIL_CMP_UGT",
+    "HLIL_FADD",
+    "HLIL_FSUB",
+    "HLIL_FMUL",
+    "HLIL_FDIV",
+    "HLIL_FSQRT",
+    "HLIL_FNEG",
+    "HLIL_FABS",
+    "HLIL_FLOAT_TO_INT",
+    "HLIL_INT_TO_FLOAT",
+    "HLIL_FLOAT_CONV",
+    "HLIL_ROUND_TO_INT",
+    "HLIL_FLOOR",
+    "HLIL_CEIL",
+    "HLIL_FTRUNC",
+    "HLIL_FCMP_E",
+    "HLIL_FCMP_NE",
+    "HLIL_FCMP_LT",
+    "HLIL_FCMP_LE",
+    "HLIL_FCMP_GE",
+    "HLIL_FCMP_GT",
+    "HLIL_FCMP_O",
+    "HLIL_FCMP_UO",
+    "HLIL_CALL",
+    "HLIL_TAILCALL",
+    "HLIL_SYSCALL",
+    "HLIL_INTRINSIC",
+    "HLIL_INTRINSIC_SSA",
+    "HLIL_BP",
+    "HLIL_TRAP",
+    "HLIL_UNDEF",
+    "HLIL_UNIMPL",
+    "HLIL_UNIMPL_MEM",
+    "HLIL_UNREACHABLE",
+    "HLIL_VAR_PHI",
+    "HLIL_MEM_PHI",
+)
+
+
+def _operation_name(op: object) -> str:
+    raw = getattr(op, "name", op)
+    text = str(raw).rsplit(".", 1)[-1]
+    return text if text.startswith("HLIL_") else f"HLIL_{text}"
+
+
+@dataclass(frozen=True)
+class MockHLILStorage:
+    """Small storage/source object for function parameters."""
+
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass(frozen=True)
+class MockHLILVar:
+    """Small Binary Ninja-like variable object."""
+
+    name: str
+    type: object = "uint32_t"
+    source: str | None = None
+    source_type: str = ""
+    storage: object | None = None
+    identifier: object | None = None
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class MockHighLevelILInstruction:
+    """Simplified stand-in for Binary Ninja's HighLevelILInstruction."""
+
+    op: str
+    named_operands: dict[str, Any] = field(default_factory=dict)
+    operand_order: list[str] = field(default_factory=list)
+    operand_types: dict[str, Any] = field(default_factory=dict)
+    text: str | None = None
+    address: int = 0
+    expr_type: object = ""
+    expr_index: int = 0
+    instr_index: int = 0
+    function: object | None = None
+    _constant: int | None = None
+
+    def __post_init__(self) -> None:
+        self.op = _operation_name(self.op)
+        if not self.operand_order:
+            self.operand_order = list(self.named_operands)
+
+    @property
+    def operation(self) -> Any:
+        """Binary Ninja-compatible operation enum for this instruction."""
+        from binaryninja.enums import HighLevelILOperation
+
+        return getattr(HighLevelILOperation, self.op)
+
+    @property
+    def operands(self) -> list[Any]:
+        """Binary Ninja-compatible positional operand list."""
+        return [
+            self.named_operands[name] for name in self.operand_order if name in self.named_operands
+        ]
+
+    @property
+    def detailed_operands(self) -> list[tuple[str, Any, Any]]:
+        """Binary Ninja-compatible named operand triples."""
+        return [
+            (name, self.named_operands[name], self.operand_types.get(name))
+            for name in self.operand_order
+            if name in self.named_operands
+        ]
+
+    @property
+    def constant(self) -> int:
+        """Binary Ninja-compatible constant value for constant expressions."""
+        if self._constant is not None:
+            return self._constant
+        if "constant" in self.named_operands:
+            return int(self.named_operands["constant"])
+        raise AttributeError("Instruction has no constant")
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self.named_operands:
+            return self.named_operands[name]
+        raise AttributeError(name)
+
+    def __str__(self) -> str:
+        if self.text is not None:
+            return self.text
+        if self.op in {"HLIL_CONST", "HLIL_CONST_PTR"}:
+            return str(self.constant)
+        if self.op == "HLIL_VAR":
+            return str(self.named_operands.get("var", ""))
+        if self.op == "HLIL_IMPORT":
+            return str(self.named_operands.get("name", self.named_operands.get("dest", "")))
+        if self.op in {"HLIL_ASSIGN", "HLIL_VAR_INIT"}:
+            return f"{self.named_operands.get('dest', self.named_operands.get('var', ''))} = {self.named_operands.get('src', '')}"
+        if self.op == "HLIL_CALL":
+            params = self.named_operands.get("params", [])
+            params_text = ", ".join(str(param) for param in _iterable(params))
+            return f"{self.named_operands.get('dest', '')}({params_text})"
+        if self.op == "HLIL_RET":
+            src = self.named_operands.get("src", [])
+            if not src:
+                return "return"
+            return "return " + ", ".join(str(item) for item in _iterable(src))
+        values = ", ".join(str(value) for value in self.operands)
+        return f"{self.op}({values})" if values else self.op
+
+
+def _iterable(value: object) -> Iterable[object]:
+    if isinstance(value, list | tuple):
+        return value
+    return (value,)
+
+
+def mhlil(
+    op: object,
+    named_operands: Mapping[str, Any] | None = None,
+    *,
+    text: str | None = None,
+    address: int = 0,
+    expr_type: object = "",
+    constant: int | None = None,
+    operand_order: Sequence[str] | None = None,
+    operand_types: Mapping[str, Any] | None = None,
+) -> MockHighLevelILInstruction:
+    """Create a single mock HLIL instruction."""
+    operands = dict(named_operands or {})
+    return MockHighLevelILInstruction(
+        op=_operation_name(op),
+        named_operands=operands,
+        operand_order=list(operand_order or operands),
+        operand_types=dict(operand_types or {}),
+        text=text,
+        address=address,
+        expr_type=expr_type,
+        _constant=constant,
+    )
+
+
+class MockHighLevelILFunction:
+    """Minimal high-level IL function with helpers for building tests."""
+
+    def __init__(
+        self,
+        instructions: Sequence[MockHighLevelILInstruction] | None = None,
+        *,
+        current_address: int = 0,
+    ) -> None:
+        self.instructions: list[MockHighLevelILInstruction] = []
+        self.current_address = current_address
+        for instruction in instructions or ():
+            self.append(instruction)
+
+    def __iter__(self) -> Iterable[MockHighLevelILInstruction]:
+        return iter(self.instructions)
+
+    def __len__(self) -> int:
+        return len(self.instructions)
+
+    def __getitem__(self, index: int) -> MockHighLevelILInstruction:
+        return self.instructions[index]
+
+    def append(self, instruction: MockHighLevelILInstruction) -> int:
+        index = len(self.instructions)
+        instruction.function = self
+        instruction.instr_index = index
+        if instruction.expr_index == 0:
+            instruction.expr_index = index
+        self.instructions.append(instruction)
+        return index
+
+    def expr(
+        self,
+        op: object,
+        named_operands: Mapping[str, Any] | None = None,
+        *,
+        text: str | None = None,
+        address: int | None = None,
+        expr_type: object = "",
+        constant: int | None = None,
+        operand_order: Sequence[str] | None = None,
+        operand_types: Mapping[str, Any] | None = None,
+    ) -> MockHighLevelILInstruction:
+        return mhlil(
+            op,
+            named_operands,
+            text=text,
+            address=self.current_address if address is None else address,
+            expr_type=expr_type,
+            constant=constant,
+            operand_order=operand_order,
+            operand_types=operand_types,
+        )
+
+    def const(
+        self,
+        value: int,
+        *,
+        expr_type: object = "int32_t",
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_CONST",
+            {"constant": value},
+            text=str(value),
+            address=address,
+            expr_type=expr_type,
+            constant=value,
+        )
+
+    def const_pointer(
+        self,
+        value: int,
+        *,
+        expr_type: object = "void *",
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_CONST_PTR",
+            {"constant": value},
+            text=hex(value),
+            address=address,
+            expr_type=expr_type,
+            constant=value,
+        )
+
+    def import_expr(
+        self,
+        name: str,
+        *,
+        address: int | None = None,
+        expr_type: object = "",
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_IMPORT",
+            {"name": name},
+            text=name,
+            address=address,
+            expr_type=expr_type,
+        )
+
+    def var(
+        self,
+        var: MockHLILVar | str,
+        *,
+        expr_type: object = "uint32_t",
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        variable = MockHLILVar(var) if isinstance(var, str) else var
+        return self.expr(
+            "HLIL_VAR",
+            {"var": variable},
+            text=str(variable),
+            address=address,
+            expr_type=expr_type,
+        )
+
+    def var_declare(
+        self,
+        var: MockHLILVar | str,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        variable = MockHLILVar(var) if isinstance(var, str) else var
+        return self.expr(
+            "HLIL_VAR_DECLARE",
+            {"var": variable},
+            text=f"{variable};",
+            address=address,
+            expr_type=getattr(variable, "type", ""),
+        )
+
+    def var_init(
+        self,
+        var: MockHLILVar | str,
+        src: object,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        variable = MockHLILVar(var) if isinstance(var, str) else var
+        return self.expr(
+            "HLIL_VAR_INIT",
+            {"var": variable, "src": src},
+            text=f"{variable} = {src}",
+            address=address,
+            expr_type=getattr(variable, "type", ""),
+            operand_order=("var", "src"),
+        )
+
+    def assign(
+        self,
+        dest: object,
+        src: object,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_ASSIGN",
+            {"dest": dest, "src": src},
+            text=f"{dest} = {src}",
+            address=address,
+            operand_order=("dest", "src"),
+        )
+
+    def ret(
+        self,
+        src: Sequence[object] | object | None = None,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        src_items = [] if src is None else list(src) if isinstance(src, list | tuple) else [src]
+        return self.expr("HLIL_RET", {"src": src_items}, address=address)
+
+    def call(
+        self,
+        dest: object,
+        params: Sequence[object] | None = None,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> MockHighLevelILInstruction:
+        params_list = list(params or [])
+        return self.expr(
+            "HLIL_CALL",
+            {"dest": dest, "params": params_list},
+            address=address,
+            expr_type=expr_type,
+            operand_order=("dest", "params"),
+        )
+
+    def unary(
+        self,
+        op: object,
+        src: object,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> MockHighLevelILInstruction:
+        return self.expr(op, {"src": src}, address=address, expr_type=expr_type)
+
+    def binary(
+        self,
+        op: object,
+        left: object,
+        right: object,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            op,
+            {"left": left, "right": right},
+            address=address,
+            expr_type=expr_type,
+            operand_order=("left", "right"),
+        )
+
+    def deref(
+        self,
+        src: object,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> MockHighLevelILInstruction:
+        return self.expr("HLIL_DEREF", {"src": src}, address=address, expr_type=expr_type)
+
+    def deref_field(
+        self,
+        src: object,
+        offset: int,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_DEREF_FIELD",
+            {"src": src, "offset": offset},
+            address=address,
+            expr_type=expr_type,
+            operand_order=("src", "offset"),
+        )
+
+    def struct_field(
+        self,
+        src: object,
+        offset: int,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_STRUCT_FIELD",
+            {"src": src, "offset": offset},
+            address=address,
+            expr_type=expr_type,
+            operand_order=("src", "offset"),
+        )
+
+    def array_index(
+        self,
+        src: object,
+        index: object,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_ARRAY_INDEX",
+            {"src": src, "index": index},
+            address=address,
+            expr_type=expr_type,
+            operand_order=("src", "index"),
+        )
+
+    def block(
+        self,
+        body: Sequence[object],
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        return self.expr("HLIL_BLOCK", {"body": list(body)}, address=address)
+
+    def if_expr(
+        self,
+        condition: object,
+        true: object,
+        false: object | None = None,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        operands: dict[str, Any] = {"condition": condition, "true": true}
+        if false is not None:
+            operands["false"] = false
+        return self.expr(
+            "HLIL_IF",
+            operands,
+            address=address,
+            operand_order=("condition", "true", "false"),
+        )
+
+    def while_expr(
+        self,
+        condition: object,
+        body: object,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_WHILE",
+            {"condition": condition, "body": body},
+            address=address,
+            operand_order=("condition", "body"),
+        )
+
+    def do_while(
+        self,
+        body: object,
+        condition: object,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_DO_WHILE",
+            {"body": body, "condition": condition},
+            address=address,
+            operand_order=("body", "condition"),
+        )
+
+    def switch(
+        self,
+        condition: object,
+        cases: Sequence[object],
+        default: object | None = None,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        operands: dict[str, Any] = {"condition": condition, "cases": list(cases)}
+        if default is not None:
+            operands["default"] = default
+        return self.expr(
+            "HLIL_SWITCH",
+            operands,
+            address=address,
+            operand_order=("condition", "cases", "default"),
+        )
+
+    def case(
+        self,
+        values: Sequence[object],
+        body: object,
+        *,
+        address: int | None = None,
+    ) -> MockHighLevelILInstruction:
+        return self.expr(
+            "HLIL_CASE",
+            {"values": list(values), "body": body},
+            address=address,
+            operand_order=("values", "body"),
+        )
+
+    def nop(self, *, address: int | None = None) -> MockHighLevelILInstruction:
+        return self.expr("HLIL_NOP", {}, address=address)
+
+    def break_expr(self, *, address: int | None = None) -> MockHighLevelILInstruction:
+        return self.expr("HLIL_BREAK", {}, address=address)
+
+    def continue_expr(self, *, address: int | None = None) -> MockHighLevelILInstruction:
+        return self.expr("HLIL_CONTINUE", {}, address=address)

--- a/src/binja_test_mocks/stubs/binaryninja/__init__.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/__init__.pyi
@@ -84,7 +84,15 @@ class InstructionInfo:
     ) -> None: ...
 
 CallingConvention: Any
+Function: Any
 InstructionTextToken: Any
+HighLevelILFunction: Any
+HighLevelILInstruction: Any
+HighLevelILOperation: Any
+MockHighLevelILFunction: Any
+MockHighLevelILInstruction: Any
+MockHLILStorage: Any
+MockHLILVar: Any
 UIContext: Any
 
 log_error: Callable[[str], None]

--- a/src/binja_test_mocks/stubs/binaryninja/enums.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/enums.pyi
@@ -9,5 +9,6 @@ Endianness: Any
 FlagRole: Any
 ImplicitRegisterExtend: Any
 ActionType: Any
+HighLevelILOperation: Any
 LowLevelILOperation: Any
 LowLevelILFlagCondition: Any

--- a/src/binja_test_mocks/stubs/binaryninja/function.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/function.pyi
@@ -7,6 +7,15 @@ from binaryninja.architecture import Architecture
 class Function:
     """Binary Ninja Function class."""
 
+    start: int
+    name: str
+    type: Any
+    return_type: Any
+    calling_convention: Any
+    parameter_vars: list[Any]
+    hlil_if_available: Any
+    high_level_il: Any
+
     @property
     def arch(self) -> Architecture:
         """The architecture of this function."""

--- a/src/binja_test_mocks/stubs/binaryninja/highlevelil.pyi
+++ b/src/binja_test_mocks/stubs/binaryninja/highlevelil.pyi
@@ -1,0 +1,139 @@
+# ruff: noqa: A002
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+HighLevelILOperation: Any
+
+class MockHLILStorage:
+    name: str
+    def __init__(self, name: str) -> None: ...
+    def __str__(self) -> str: ...
+
+class MockHLILVar:
+    name: str
+    type: object
+    source: str | None
+    source_type: str
+    storage: object | None
+    identifier: object | None
+    def __init__(
+        self,
+        name: str,
+        type: object = "uint32_t",
+        source: str | None = None,
+        source_type: str = "",
+        storage: object | None = None,
+        identifier: object | None = None,
+    ) -> None: ...
+    def __str__(self) -> str: ...
+
+class HighLevelILInstruction:
+    op: str
+    named_operands: dict[str, Any]
+    operand_order: list[str]
+    operand_types: dict[str, Any]
+    text: str | None
+    address: int
+    expr_type: object
+    expr_index: int
+    instr_index: int
+    function: object | None
+    @property
+    def operation(self) -> Any: ...
+    @property
+    def operands(self) -> list[Any]: ...
+    @property
+    def detailed_operands(self) -> list[tuple[str, Any, Any]]: ...
+    @property
+    def constant(self) -> int: ...
+
+class HighLevelILFunction:
+    instructions: list[HighLevelILInstruction]
+    current_address: int
+    def __init__(
+        self,
+        instructions: Sequence[HighLevelILInstruction] | None = None,
+        *,
+        current_address: int = 0,
+    ) -> None: ...
+    def __iter__(self) -> Iterable[HighLevelILInstruction]: ...
+    def __len__(self) -> int: ...
+    def __getitem__(self, index: int) -> HighLevelILInstruction: ...
+    def append(self, instruction: HighLevelILInstruction) -> int: ...
+    def expr(
+        self,
+        op: object,
+        named_operands: Mapping[str, Any] | None = None,
+        *,
+        text: str | None = None,
+        address: int | None = None,
+        expr_type: object = "",
+        constant: int | None = None,
+        operand_order: Sequence[str] | None = None,
+        operand_types: Mapping[str, Any] | None = None,
+    ) -> HighLevelILInstruction: ...
+    def const(
+        self, value: int, *, expr_type: object = "int32_t", address: int | None = None
+    ) -> HighLevelILInstruction: ...
+    def const_pointer(
+        self, value: int, *, expr_type: object = "void *", address: int | None = None
+    ) -> HighLevelILInstruction: ...
+    def import_expr(
+        self, name: str, *, address: int | None = None, expr_type: object = ""
+    ) -> HighLevelILInstruction: ...
+    def var(
+        self, var: MockHLILVar | str, *, expr_type: object = "uint32_t", address: int | None = None
+    ) -> HighLevelILInstruction: ...
+    def var_declare(
+        self, var: MockHLILVar | str, *, address: int | None = None
+    ) -> HighLevelILInstruction: ...
+    def var_init(
+        self, var: MockHLILVar | str, src: object, *, address: int | None = None
+    ) -> HighLevelILInstruction: ...
+    def assign(
+        self, dest: object, src: object, *, address: int | None = None
+    ) -> HighLevelILInstruction: ...
+    def ret(
+        self, src: Sequence[object] | object | None = None, *, address: int | None = None
+    ) -> HighLevelILInstruction: ...
+    def call(
+        self,
+        dest: object,
+        params: Sequence[object] | None = None,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> HighLevelILInstruction: ...
+    def unary(
+        self,
+        op: object,
+        src: object,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> HighLevelILInstruction: ...
+    def binary(
+        self,
+        op: object,
+        left: object,
+        right: object,
+        *,
+        address: int | None = None,
+        expr_type: object = "uint32_t",
+    ) -> HighLevelILInstruction: ...
+
+MockHighLevelILInstruction = HighLevelILInstruction
+MockHighLevelILFunction = HighLevelILFunction
+
+def mhlil(
+    op: object,
+    named_operands: Mapping[str, Any] | None = None,
+    *,
+    text: str | None = None,
+    address: int = 0,
+    expr_type: object = "",
+    constant: int | None = None,
+    operand_order: Sequence[str] | None = None,
+    operand_types: Mapping[str, Any] | None = None,
+) -> HighLevelILInstruction: ...

--- a/tests/test_mock_hlil.py
+++ b/tests/test_mock_hlil.py
@@ -1,0 +1,94 @@
+"""Regression tests for mock HLIL helpers."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any
+
+import pytest
+
+os.environ["FORCE_BINJA_MOCK"] = "1"
+
+
+def _walk_hlil_ops(root: Any) -> set[str]:
+    nodes = list(getattr(root, "instructions", []) or [])
+    ops: set[str] = set()
+    while nodes:
+        node = nodes.pop()
+        ops.add(str(node.operation).rsplit(".", 1)[-1])
+        for child in getattr(node, "operands", []) or []:
+            if hasattr(child, "operation"):
+                nodes.append(child)
+            elif isinstance(child, list | tuple):
+                nodes.extend(item for item in child if hasattr(item, "operation"))
+    return ops
+
+
+def test_mock_hlil_instruction_surface() -> None:
+    importlib.import_module("binja_test_mocks.binja_api")
+
+    from binaryninja.enums import HighLevelILOperation
+
+    from binja_test_mocks.mock_hlil import MockHighLevelILFunction, MockHLILVar
+
+    il = MockHighLevelILFunction(current_address=0x401000)
+    var = MockHLILVar("result", type="uint32_t")
+    one = il.const(1)
+    two = il.const(2)
+    add = il.binary(HighLevelILOperation.HLIL_ADD, one, two)
+    init = il.var_init(var, add)
+
+    assert add.operation == HighLevelILOperation.HLIL_ADD
+    assert add.operands == [one, two]
+    assert [name for name, _value, _operand_type in add.detailed_operands] == ["left", "right"]
+    assert add.address == 0x401000
+    assert one.constant == 1
+    assert two.constant == 2
+    assert init.var == var
+    assert init.src is add
+
+    with pytest.raises(AttributeError):
+        _ = add.constant
+
+
+def test_mock_hlil_function_metadata_and_nested_operands() -> None:
+    importlib.import_module("binja_test_mocks.binja_api")
+
+    from binaryninja.function import Function
+
+    from binja_test_mocks.mock_hlil import (
+        MockHighLevelILFunction,
+        MockHLILStorage,
+        MockHLILVar,
+    )
+
+    il = MockHighLevelILFunction(current_address=0x401020)
+    result = MockHLILVar("result", type="uint32_t", source="eax", storage=MockHLILStorage("eax"))
+    time_get_time = il.import_expr("timeGetTime")
+    call = il.call(time_get_time, [])
+    il.append(il.var_init(result, call))
+    il.append(il.ret([il.var(result)]))
+
+    func = Function(
+        start=0x401020,
+        name="read_tick",
+        return_type="uint32_t",
+        type="uint32_t read_tick()",
+        high_level_il=il,
+        parameter_vars=[result],
+    )
+
+    assert func.start == 0x401020
+    assert func.name == "read_tick"
+    assert func.hlil_if_available is il
+    assert func.high_level_il is il
+    assert len(func.parameter_vars) == 1
+    assert str(time_get_time) == "timeGetTime"
+    assert _walk_hlil_ops(il) == {
+        "HLIL_CALL",
+        "HLIL_IMPORT",
+        "HLIL_RET",
+        "HLIL_VAR",
+        "HLIL_VAR_INIT",
+    }


### PR DESCRIPTION
## Summary

Adds a minimal High Level IL mock surface for Binary Ninja plugin tests:

- introduces mock HLIL instructions, variables, storage objects, and functions
- exposes `HighLevelILOperation` through `binaryninja.enums`, `binaryninja.highlevelil`, and the root mock module
- adds packaged type stubs for the new HLIL symbols
- covers nested HLIL operands and function metadata consumed by downstream analysis code

## Validation

- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `FORCE_BINJA_MOCK=1 uv run --frozen pytest tests -q`
- `FORCE_BINJA_MOCK=1 uv run --frozen mypy .`
- `FORCE_BINJA_MOCK=1 uv run --frozen pyright`
- `uv build --no-sources`